### PR TITLE
Remove Java 11 requirements

### DIFF
--- a/runme
+++ b/runme
@@ -174,7 +174,7 @@ done
 
 # START HERE
 
-if [[ !  -e /etc/issue ]] ||  ! grep "Raspbian" /etc/issue > /dev/null  ; then
+if [[ !  -e /etc/issue ]] ||  ! grep "Debian" /etc/issue > /dev/null  ; then
     echo Please run this script on Raspian GNU/Linux.
     echo You can download Linux from the Raspberry Pi website at https://www.raspberrypi.org/downloads/raspbian/
     echo 'The Lite version is recommended to save space, but the full version will also work'
@@ -221,38 +221,19 @@ fi
 
 chmod aog+x "$INSTALLER_FILE"
 
-echo Adding Debian Bookworm Backports for Java 11 support
+echo Adding Debian Bookworm Backports. Java 17 appears to work and it is already installed
 echo
 
-sudo wget https://ftp-master.debian.org/keys/archive-key-12.asc -O /tmp/archive-key-8.asc
-sudo apt-key add /tmp/archive-key-8.asc
-echo 'deb http://deb.debian.org/debian unstable main non-free contrib' | sudo tee -a /etc/apt/sources.list
-
-# Define the content to be added
-content='Package: *
-Pin: release a=stable
-Pin-Priority: 900
-
-Package: *
-Pin: release a=unstable
-Pin-Priority: 50'
-
-# Append the content to /etc/apt/preferences
-echo "$content" | sudo tee -a /etc/apt/preferences
-
-echo "The content has been added to /etc/apt/preferences."
 echo About to upgrade Raspian to the latest version -- this may take some time
 echo
 
 sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get dist-upgrade -y
 
 echo About to install X Windows and the Java runtime if required -- this may take some time
-sudo apt-get install -y xorg xinit openjdk-11-jre pwgen matchbox-keyboard
+sudo apt-get install -y xorg xinit pwgen matchbox-keyboard
 sudo apt-get autoremove
 sudo apt-get clean
 echo
-
-sudo update-alternatives --config java
 
 sudo sed -i -e '/\(trap.*2\)\|\(set.*\+m\)/d' /etc/profile
 

--- a/runme
+++ b/runme
@@ -221,15 +221,12 @@ fi
 
 chmod aog+x "$INSTALLER_FILE"
 
-echo Adding Debian Bookworm Backports. Java 17 appears to work and it is already installed
-echo
-
 echo About to upgrade Raspian to the latest version -- this may take some time
 echo
 
 sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get dist-upgrade -y
 
-echo About to install X Windows and the Java runtime if required -- this may take some time
+echo About to install X Windows if required -- this may take some time
 sudo apt-get install -y xorg xinit pwgen matchbox-keyboard
 sudo apt-get autoremove
 sudo apt-get clean


### PR DESCRIPTION
Based upon testing, it seems that Java 17 works with Papercut's software. Removing Java 11 requirement and using Java 17 which comes pre-installed on Raspberry Pi OS